### PR TITLE
Add Quatt Chill device support

### DIFF
--- a/custom_components/quatt/__init__.py
+++ b/custom_components/quatt/__init__.py
@@ -17,6 +17,7 @@ from homeassistant.core import (
     ServiceCall,
     ServiceResponse,
     SupportsResponse,
+    callback,
 )
 from homeassistant.helpers.aiohttp_client import (
     async_create_clientsession,
@@ -59,6 +60,7 @@ from .coordinator_remote_cic import QuattCicRemoteDataUpdateCoordinator
 
 PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
+    Platform.CLIMATE,
     Platform.NUMBER,
     Platform.SELECT,
     Platform.SENSOR,
@@ -312,6 +314,44 @@ def _register_services(hass: HomeAssistant) -> None:
     _register_get_home_battery_savings_service(hass)
 
 
+@callback
+def _sync_chill_device_names(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    remote_coordinator: QuattCicRemoteDataUpdateCoordinator,
+) -> None:
+    """Update Chill device names in the device registry from the latest API data."""
+    chill_list = remote_coordinator.get_value("chills", [])
+    if not isinstance(chill_list, list):
+        return
+
+    device_reg = dr.async_get(hass)
+    hub_id = (entry.unique_id or entry.entry_id).strip()
+
+    for chill in chill_list:
+        if not isinstance(chill, dict):
+            continue
+
+        chill_uuid = chill.get("uuid")
+        chill_name = chill.get("name")
+        if not chill_uuid or not chill_name:
+            continue
+
+        device = device_reg.async_get_device(
+            identifiers={(DOMAIN, f"{hub_id}:{chill_uuid}")}
+        )
+        if device is None or device.name == chill_name:
+            continue
+
+        LOGGER.info(
+            "Updating Chill device name for %s from %s to %s",
+            chill_uuid,
+            device.name,
+            chill_name,
+        )
+        device_reg.async_update_device(device.id, name=chill_name)
+
+
 # https://developers.home-assistant.io/docs/config_entries_index/#setting-up-an-entry
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up this integration using UI."""
@@ -420,6 +460,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data[DOMAIN][entry.entry_id] = coordinators
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    if (remote_coordinator := coordinators.get("cic_remote")) is not None:
+        entry.async_on_unload(
+            remote_coordinator.async_add_listener(
+                lambda: _sync_chill_device_names(hass, entry, remote_coordinator)
+            )
+        )
+
     # On update of the options reload the entry which reloads the coordinator
     entry.async_on_unload(entry.add_update_listener(update_listener))
 

--- a/custom_components/quatt/api_remote_cic.py
+++ b/custom_components/quatt/api_remote_cic.py
@@ -89,9 +89,7 @@ class QuattCicRemoteApiClient(QuattApiClient):
                     await self._auth.save_tokens()
                     cic_data = await self.get_cic_data()
                     if cic_data:
-                        _LOGGER.info(
-                            "Successfully authenticated with refreshed token"
-                        )
+                        _LOGGER.info("Successfully authenticated with refreshed token")
                         return True
 
                 # Existing tokens no longer usable - reset and fall through
@@ -210,6 +208,33 @@ class QuattCicRemoteApiClient(QuattApiClient):
             return data
         return None
 
+    async def get_chills(
+        self,
+        installation_id: str | None = None,
+        retry_on_403: bool = True,
+    ) -> list[dict[str, Any]] | None:
+        """Fetch chill device data for the installation."""
+        if not self._auth.is_authenticated:
+            return None
+
+        installation_id = installation_id or self._installation_id
+        if not installation_id:
+            _LOGGER.debug("No installation ID available, skipping chill data fetch")
+            return None
+
+        status, data = await self._auth.request(
+            "GET",
+            f"/me/installation/{installation_id}/devices/chills",
+            retry_on_auth_error=retry_on_403,
+        )
+        if status == 200 and isinstance(data, dict):
+            result = data.get("result")
+            if isinstance(result, dict):
+                chills = result.get("chills")
+                if isinstance(chills, list):
+                    return chills
+        return None
+
     async def async_get_data(self, retry_on_client_error: bool = False) -> Any:
         """Get data for the coordinator (CIC feed + insights)."""
         cic_data = await self.get_cic_data()
@@ -218,8 +243,23 @@ class QuattCicRemoteApiClient(QuattApiClient):
 
         result = cic_data.get("result", {})
 
+        installation_id = self._installation_id or result.get("installationId")
+
+        if not installation_id:
+            _LOGGER.debug(
+                "No installation ID available, skipping chills and insights fetch"
+            )
+            return result
+
+        if result.get("hasChills"):
+            chills = await self.get_chills(installation_id=installation_id)
+            if chills is not None:
+                result["chills"] = chills
+
         if not self._installation_id:
-            _LOGGER.debug("No installation ID available, skipping insights fetch")
+            _LOGGER.debug(
+                "No persisted installation ID available, skipping insights fetch"
+            )
             return result
 
         insights_data = await self.get_insights()
@@ -265,9 +305,7 @@ class QuattCicRemoteApiClient(QuattApiClient):
         if status == 200 and isinstance(data, dict):
             result = data.get("result", {})
             fetched_at = datetime.now(timezone.utc)  # noqa: UP017
-            expires_at = fetched_at + timedelta(
-                minutes=INSIGHTS_REMOTE_SCAN_INTERVAL
-            )
+            expires_at = fetched_at + timedelta(minutes=INSIGHTS_REMOTE_SCAN_INTERVAL)
             self._insights_cache[key] = (expires_at, result)
 
             # Cleanup expired cache entries (keeps memory bounded over time)
@@ -300,4 +338,28 @@ class QuattCicRemoteApiClient(QuattApiClient):
             _LOGGER.debug("CIC settings updated successfully: %s", settings)
             return True
         _LOGGER.error("CIC settings update failed with status %s", status)
+        return False
+
+    async def update_chill_action(self, chill_uuid: str, data: dict[str, Any]) -> bool:
+        """Update chill device action."""
+        if not self._auth.is_authenticated:
+            _LOGGER.error("Cannot update chill action: not authenticated")
+            return False
+
+        if not self._installation_id:
+            _LOGGER.error("Cannot update chill action: no installation ID")
+            return False
+
+        status, _data = await self._auth.request(
+            "POST",
+            f"/me/installation/{self._installation_id}/devices/chills/{chill_uuid}/actions",
+            json_body=data,
+            expected_statuses=(200, 201, 204),
+        )
+        if status in (200, 201, 204):
+            _LOGGER.debug(
+                "Chill action updated successfully: %s for %s", data, chill_uuid
+            )
+            return True
+        _LOGGER.error("Chill action update failed with status %s", status)
         return False

--- a/custom_components/quatt/binary_sensor.py
+++ b/custom_components/quatt/binary_sensor.py
@@ -28,9 +28,10 @@ from .coordinator import QuattDataUpdateCoordinator
 from .entity import (
     QuattBinarySensor,
     QuattBinarySensorEntityDescription,
+    QuattChillBinarySensor,
     QuattFeatureFlags,
 )
-from .entity_setup import async_setup_entities
+from .entity_setup import async_setup_entities, create_chill_entity_descriptions
 
 
 def create_heatpump_sensor_entity_descriptions(
@@ -346,6 +347,35 @@ BINARY_SENSORS = {
     DEVICE_HEAT_CHARGER_ID: [],
 }
 
+
+def create_chill_binary_sensor_entity_descriptions(
+    index: int,
+) -> list[QuattBinarySensorEntityDescription]:
+    """Create binary sensor entity descriptions for a chill device."""
+    return [
+        QuattBinarySensorEntityDescription(
+            name="Power",
+            key=f"chills.{index}.isOn.value",
+            icon="mdi:power",
+            device_class=BinarySensorDeviceClass.POWER,
+            quatt_features=QuattFeatureFlags(
+                mobile_api=True,
+            ),
+            quatt_entity_class=QuattChillBinarySensor,
+        ),
+        QuattBinarySensorEntityDescription(
+            name="Water tank warning",
+            key=f"chills.{index}.hasWaterTankLevelWarning",
+            icon="mdi:water-alert",
+            device_class=BinarySensorDeviceClass.PROBLEM,
+            quatt_features=QuattFeatureFlags(
+                mobile_api=True,
+            ),
+            quatt_entity_class=QuattChillBinarySensor,
+        ),
+    ]
+
+
 HOME_BATTERY_BINARY_SENSORS: list[QuattBinarySensorEntityDescription] = [
     QuattBinarySensorEntityDescription(
         key="connected",
@@ -365,7 +395,9 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
     coordinators = hass.data[DOMAIN][entry.entry_id]
 
     local_coordinator: QuattDataUpdateCoordinator | None = coordinators.get("cic_local")
-    remote_coordinator: QuattDataUpdateCoordinator | None = coordinators.get("cic_remote")
+    remote_coordinator: QuattDataUpdateCoordinator | None = coordinators.get(
+        "cic_remote"
+    )
     home_battery_coordinator: QuattDataUpdateCoordinator | None = coordinators.get(
         "home_battery"
     )
@@ -383,13 +415,23 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
         )
 
     if remote_coordinator:
+        entity_descriptions, device_names, device_kinds = (
+            create_chill_entity_descriptions(
+                remote_coordinator,
+                BINARY_SENSORS,
+                create_chill_binary_sensor_entity_descriptions,
+            )
+        )
+
         sensors += await async_setup_entities(
             hass=hass,
             coordinator=remote_coordinator,
             entry=entry,
             remote=True,
-            entity_descriptions=BINARY_SENSORS,
+            entity_descriptions=entity_descriptions,
             entity_domain=BINARY_SENSOR_DOMAIN,
+            device_names=device_names,
+            device_kinds=device_kinds,
         )
 
     if home_battery_coordinator is not None:

--- a/custom_components/quatt/climate.py
+++ b/custom_components/quatt/climate.py
@@ -1,0 +1,85 @@
+"""Climate platform for quatt."""
+
+from __future__ import annotations
+
+from homeassistant.components.climate import DOMAIN as CLIMATE_DOMAIN
+from homeassistant.core import HomeAssistant
+
+from .const import (
+    DEVICE_BOILER_ID,
+    DEVICE_CIC_ID,
+    DEVICE_FLOWMETER_ID,
+    DEVICE_HEAT_BATTERY_ID,
+    DEVICE_HEAT_CHARGER_ID,
+    DEVICE_HEATPUMP_1_ID,
+    DEVICE_HEATPUMP_2_ID,
+    DEVICE_THERMOSTAT_ID,
+    DOMAIN,
+)
+from .coordinator import QuattDataUpdateCoordinator
+from .entity import (
+    QuattChillClimate,
+    QuattClimateEntityDescription,
+    QuattFeatureFlags,
+)
+from .entity_setup import async_setup_entities, create_chill_entity_descriptions
+
+CLIMATES = {
+    # The HUB CIC sensor must be created first to ensure the HUB device is present
+    DEVICE_CIC_ID: [],
+    DEVICE_HEAT_BATTERY_ID: [],
+    DEVICE_HEAT_CHARGER_ID: [],
+    DEVICE_HEATPUMP_1_ID: [],
+    DEVICE_HEATPUMP_2_ID: [],
+    DEVICE_BOILER_ID: [],
+    DEVICE_FLOWMETER_ID: [],
+    DEVICE_THERMOSTAT_ID: [],
+}
+
+
+def create_chill_climate_entity_descriptions(
+    index: int,
+) -> list[QuattClimateEntityDescription]:
+    """Create the chill climate entity descriptions based on the index."""
+    return [
+        QuattClimateEntityDescription(
+            key=f"chills.{index}",
+            quatt_features=QuattFeatureFlags(
+                mobile_api=True,
+            ),
+            quatt_entity_class=QuattChillClimate,
+        )
+    ]
+
+
+async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
+    """Set up the climate platform."""
+    coordinators = hass.data[DOMAIN][entry.entry_id]
+
+    remote_coordinator: QuattDataUpdateCoordinator | None = coordinators.get(
+        "cic_remote"
+    )
+
+    climates: list[QuattChillClimate] = []
+
+    if remote_coordinator:
+        entity_descriptions, device_names, device_kinds = (
+            create_chill_entity_descriptions(
+                remote_coordinator,
+                CLIMATES,
+                create_chill_climate_entity_descriptions,
+            )
+        )
+
+        climates += await async_setup_entities(
+            hass=hass,
+            coordinator=remote_coordinator,
+            entry=entry,
+            remote=True,
+            entity_descriptions=entity_descriptions,
+            entity_domain=CLIMATE_DOMAIN,
+            device_names=device_names,
+            device_kinds=device_kinds,
+        )
+
+    async_add_devices(climates)

--- a/custom_components/quatt/const.py
+++ b/custom_components/quatt/const.py
@@ -81,6 +81,7 @@ DEVICE_HOME_BATTERY_ID = "home_battery"
 DEVICE_HOME_BATTERY_SAVINGS_ID = "home_battery_savings"
 DEVICE_HOME_BATTERY_INSIGHTS_ID = "home_battery_insights"
 DEVICE_HOME_BATTERY_ENERGY_FLOW_ID = "home_battery_energy_flow"
+DEVICE_CHILL_ID = "chill"
 
 
 class QuattDeviceKind(StrEnum):
@@ -95,6 +96,7 @@ DEVICE_LIST = [
     {"name": "Boiler", "id": DEVICE_BOILER_ID, "kind": QuattDeviceKind.DEVICE},
     {"name": "CIC", "id": DEVICE_CIC_ID, "kind": QuattDeviceKind.HUB},
     {"name": "Flowmeter", "id": DEVICE_FLOWMETER_ID, "kind": QuattDeviceKind.DEVICE},
+    {"name": "Chill", "id": DEVICE_CHILL_ID, "kind": QuattDeviceKind.DEVICE},
     {
         "name": "Heat battery",
         "id": DEVICE_HEAT_BATTERY_ID,
@@ -105,14 +107,10 @@ DEVICE_LIST = [
         "id": DEVICE_HEAT_CHARGER_ID,
         "kind": QuattDeviceKind.DEVICE,
     },
-    {"name": "Heatpump 1", "id": DEVICE_HEATPUMP_1_ID,
-        "kind": QuattDeviceKind.DEVICE},
-    {"name": "Heatpump 2", "id": DEVICE_HEATPUMP_2_ID,
-        "kind": QuattDeviceKind.DEVICE},
-    {"name": "Thermostat", "id": DEVICE_THERMOSTAT_ID,
-        "kind": QuattDeviceKind.DEVICE},
-    {"name": "Insights", "id": DEVICE_CIC_INSIGHTS_ID,
-        "kind": QuattDeviceKind.SERVICE},
+    {"name": "Heatpump 1", "id": DEVICE_HEATPUMP_1_ID, "kind": QuattDeviceKind.DEVICE},
+    {"name": "Heatpump 2", "id": DEVICE_HEATPUMP_2_ID, "kind": QuattDeviceKind.DEVICE},
+    {"name": "Thermostat", "id": DEVICE_THERMOSTAT_ID, "kind": QuattDeviceKind.DEVICE},
+    {"name": "Insights", "id": DEVICE_CIC_INSIGHTS_ID, "kind": QuattDeviceKind.SERVICE},
     {"name": "Home battery", "id": DEVICE_HOME_BATTERY_ID, "kind": QuattDeviceKind.HUB},
     {
         "name": "Savings",

--- a/custom_components/quatt/entity.py
+++ b/custom_components/quatt/entity.py
@@ -3,15 +3,24 @@
 from __future__ import annotations
 
 from abc import abstractmethod
+from collections.abc import Mapping
+from copy import deepcopy
 from dataclasses import dataclass
 from datetime import date, datetime
 from decimal import Decimal
+from enum import Enum
 import logging
 from typing import Any
 
 from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
     BinarySensorEntityDescription,
+)
+from homeassistant.components.climate import (
+    ClimateEntity,
+    ClimateEntityDescription,
+    ClimateEntityFeature,
+    HVACMode,
 )
 from homeassistant.components.number import (
     DEFAULT_MAX_VALUE,
@@ -27,6 +36,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
 )
 from homeassistant.components.switch import SwitchEntity, SwitchEntityDescription
+from homeassistant.const import PRECISION_TENTHS, UnitOfTemperature
 from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.typing import StateType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -49,6 +59,93 @@ from .coordinator_remote_cic import QuattCicRemoteDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
+CHILL_SENTENCE_CASE_KEYS = {"color", "fanMode", "mode", "status", "updateState"}
+
+
+def _format_chill_sentence_case(value: str) -> str:
+    """Format Quatt Chill enum text as sentence case."""
+    text = value.replace("_", " ").lower()
+    return text[:1].upper() + text[1:]
+
+
+class QuattChillApiEnum(str, Enum):
+    """Base class for Quatt Chill API enum values."""
+
+    @classmethod
+    def from_api_value(cls, value: Any):
+        """Return the enum member for a case-insensitive API value."""
+        if not isinstance(value, str):
+            return None
+
+        normalized_value = value.upper()
+        for item in cls:
+            if item.value == normalized_value:
+                return item
+        return None
+
+    @classmethod
+    def from_display_value(cls, value: str):
+        """Return the enum member for a display value."""
+        normalized_value = value.replace(" ", "_").upper()
+        return cls.from_api_value(normalized_value)
+
+    @property
+    def display_value(self) -> str:
+        """Return the Home Assistant display value."""
+        return _format_chill_sentence_case(self.value)
+
+
+class QuattChillFanMode(QuattChillApiEnum):
+    """Quatt Chill fan mode values."""
+
+    HIGH = "HIGH"
+    NORMAL = "NORMAL"
+    LOW = "LOW"
+
+
+class QuattChillMode(QuattChillApiEnum):
+    """Quatt Chill mode values."""
+
+    COOLING = "COOLING"
+    HEATING = "HEATING"
+
+    @property
+    def hvac_mode(self) -> HVACMode:
+        """Return the matching Home Assistant HVAC mode."""
+        return HVACMode.COOL if self == QuattChillMode.COOLING else HVACMode.HEAT
+
+
+class QuattChillStatus(QuattChillApiEnum):
+    """Quatt Chill status values."""
+
+    OFF = "OFF"
+    OFFLINE = "OFFLINE"
+    COOLING = "COOLING"
+    HEATING = "HEATING"
+
+    @property
+    def hvac_mode(self) -> HVACMode:
+        """Return the matching Home Assistant HVAC mode."""
+        if self in {QuattChillStatus.OFF, QuattChillStatus.OFFLINE}:
+            return HVACMode.OFF
+        return HVACMode.COOL if self == QuattChillStatus.COOLING else HVACMode.HEAT
+
+
+def _format_chill_enum_value(key: str, value: str) -> str:
+    """Format a Quatt Chill enum text value for Home Assistant."""
+    enum_class: type[QuattChillApiEnum] | None = {
+        "fanMode": QuattChillFanMode,
+        "mode": QuattChillMode,
+        "status": QuattChillStatus,
+    }.get(key)
+
+    if enum_class:
+        if enum_value := enum_class.from_api_value(value):
+            return enum_value.display_value
+        _LOGGER.debug("Unknown Chill %s value: %s", key, value)
+
+    return _format_chill_sentence_case(value)
+
 
 class QuattEntity(CoordinatorEntity[QuattDataUpdateCoordinator]):
     """QuattEntity class."""
@@ -63,6 +160,7 @@ class QuattEntity(CoordinatorEntity[QuattDataUpdateCoordinator]):
         sensor_key: str,
         coordinator: QuattDataUpdateCoordinator,
         device_kind: QuattDeviceKind,
+        unique_id_key: str | None = None,
     ) -> None:
         """Initialize."""
         super().__init__(coordinator)
@@ -77,7 +175,7 @@ class QuattEntity(CoordinatorEntity[QuattDataUpdateCoordinator]):
 
         self._device_name = device_name
         self._device_id = device_id
-        self._attr_unique_id = f"{self._hub_id}:{device_id}:{sensor_key}"
+        self._attr_unique_id = f"{self._hub_id}:{device_id}:{unique_id_key or sensor_key}"
 
         attach_to_hub = device_kind == QuattDeviceKind.HUB
         is_service_device = device_kind == QuattDeviceKind.SERVICE
@@ -100,6 +198,28 @@ class QuattEntity(CoordinatorEntity[QuattDataUpdateCoordinator]):
                 entry_type=DeviceEntryType.SERVICE if is_service_device else None,
             )
 
+    def _current_chill_index(self) -> int | None:
+        """Return the current Chill list index for this entity's device."""
+        chills = self.coordinator.get_value("chills", [])
+        if not isinstance(chills, list):
+            return None
+
+        for index, chill in enumerate(chills):
+            if isinstance(chill, dict) and chill.get("uuid") == self._device_id:
+                return index
+
+        return None
+
+    @staticmethod
+    def _chill_key_at_index(key: str, index: int) -> str:
+        """Return a Chill coordinator key for the current response-list index."""
+        key_parts = key.split(".", 2)
+        if len(key_parts) < 2 or key_parts[0] != "chills":
+            return key
+        if len(key_parts) == 2:
+            return f"chills.{index}"
+        return f"chills.{index}.{key_parts[2]}"
+
 
 class QuattSensor(QuattEntity, SensorEntity):
     """Quatt Sensor class."""
@@ -114,7 +234,14 @@ class QuattSensor(QuattEntity, SensorEntity):
         device_kind: QuattDeviceKind,
     ) -> None:
         """Initialize the sensor class."""
-        super().__init__(device_name, device_id, sensor_key, coordinator, device_kind)
+        super().__init__(
+            device_name,
+            device_id,
+            sensor_key,
+            coordinator,
+            device_kind,
+            entity_description.quatt_unique_id_key,
+        )
         self.entity_description = entity_description
 
     @property
@@ -134,6 +261,36 @@ class QuattSensor(QuattEntity, SensorEntity):
             value = dt_util.parse_datetime(value)
 
         return value
+
+
+class QuattChillSensor(QuattSensor):
+    """Quatt Chill sensor class."""
+
+    @property
+    def native_value(self) -> StateType | date | datetime | Decimal:
+        """Return the native value of the Chill sensor."""
+        chill_index = self._current_chill_index()
+        if chill_index is None:
+            return None
+
+        value = self.coordinator.get_value(
+            self._chill_key_at_index(self.entity_description.key, chill_index)
+        )
+
+        if value is None:
+            return None
+
+        if self.entity_description.device_class == SensorDeviceClass.TIMESTAMP:
+            value = dt_util.parse_datetime(value)
+
+        if not isinstance(value, str):
+            return value
+
+        key = self.entity_description.key.rsplit(".", 1)[-1]
+        if key not in CHILL_SENTENCE_CASE_KEYS:
+            return value
+
+        return _format_chill_enum_value(key, value)
 
 
 class QuattSystemSensor(QuattSensor):
@@ -162,7 +319,14 @@ class QuattBinarySensor(QuattEntity, BinarySensorEntity):
         device_kind: QuattDeviceKind,
     ) -> None:
         """Initialize the binary_sensor class."""
-        super().__init__(device_name, device_id, sensor_key, coordinator, device_kind)
+        super().__init__(
+            device_name,
+            device_id,
+            sensor_key,
+            coordinator,
+            device_kind,
+            entity_description.quatt_unique_id_key,
+        )
         self.entity_description = entity_description
 
     @property
@@ -174,6 +338,20 @@ class QuattBinarySensor(QuattEntity, BinarySensorEntity):
     def is_on(self) -> bool:
         """Return true if the binary_sensor is on."""
         return self.coordinator.get_value(self.entity_description.key)
+
+
+class QuattChillBinarySensor(QuattBinarySensor):
+    """Quatt Chill binary sensor class."""
+
+    @property
+    def is_on(self) -> bool:
+        """Return true if the Chill binary sensor is on."""
+        chill_index = self._current_chill_index()
+        if chill_index is None:
+            return False
+        return self.coordinator.get_value(
+            self._chill_key_at_index(self.entity_description.key, chill_index)
+        )
 
 
 class QuattSelect(QuattEntity, SelectEntity):
@@ -189,7 +367,14 @@ class QuattSelect(QuattEntity, SelectEntity):
         device_kind: QuattDeviceKind,
     ) -> None:
         """Initialize the select class."""
-        super().__init__(device_name, device_id, sensor_key, coordinator, device_kind)
+        super().__init__(
+            device_name,
+            device_id,
+            sensor_key,
+            coordinator,
+            device_kind,
+            entity_description.quatt_unique_id_key,
+        )
         self.entity_description = entity_description
 
     @property
@@ -251,7 +436,9 @@ class QuattSoundSelect(QuattSelect):
 
         remote_client = self.coordinator.client
         if not isinstance(remote_client, QuattCicRemoteApiClient):
-            _LOGGER.error("Cannot update %s: remote client required", self.entity_description.key)
+            _LOGGER.error(
+                "Cannot update %s: remote client required", self.entity_description.key
+            )
             return False
 
         # Get current values for both sound levels
@@ -296,7 +483,14 @@ class QuattSwitch(QuattEntity, SwitchEntity):
         device_kind: QuattDeviceKind,
     ) -> None:
         """Initialize the switch class."""
-        super().__init__(device_name, device_id, sensor_key, coordinator, device_kind)
+        super().__init__(
+            device_name,
+            device_id,
+            sensor_key,
+            coordinator,
+            device_kind,
+            entity_description.quatt_unique_id_key,
+        )
         self.entity_description = entity_description
 
     @property
@@ -369,7 +563,9 @@ class QuattSettingSwitch(QuattSwitch):
         """Perform boolean setting update."""
         remote_client = self.coordinator.client
         if not isinstance(remote_client, QuattCicRemoteApiClient):
-            _LOGGER.error("Cannot update %s: remote client required", self.entity_description.key)
+            _LOGGER.error(
+                "Cannot update %s: remote client required", self.entity_description.key
+            )
             return False
 
         # Convert dot notation to nested object structure
@@ -404,7 +600,14 @@ class QuattNumber(QuattEntity, NumberEntity):
         device_kind: QuattDeviceKind,
     ) -> None:
         """Initialize the number class."""
-        super().__init__(device_name, device_id, sensor_key, coordinator, device_kind)
+        super().__init__(
+            device_name,
+            device_id,
+            sensor_key,
+            coordinator,
+            device_kind,
+            entity_description.quatt_unique_id_key,
+        )
         self.entity_description = entity_description
 
     @property
@@ -526,9 +729,7 @@ class QuattHomeBatterySolarCapacityNumber(QuattNumber):
 
     async def async_set_native_value(self, value: float) -> None:
         """Set the new value via the home battery coordinator."""
-        if not isinstance(
-            self.coordinator, QuattHomeBatteryDataUpdateCoordinator
-        ):
+        if not isinstance(self.coordinator, QuattHomeBatteryDataUpdateCoordinator):
             _LOGGER.error(
                 "Cannot update %s: home battery coordinator required",
                 self.entity_description.key,
@@ -546,9 +747,7 @@ class QuattHomeBatterySolarCapacityNumber(QuattNumber):
             ) from err
 
         if not success:
-            raise RuntimeError(
-                f"Failed to update {self.entity_description.key}"
-            )
+            raise RuntimeError(f"Failed to update {self.entity_description.key}")
 
         await self.coordinator.async_request_refresh()
 
@@ -604,6 +803,7 @@ class QuattSensorEntityDescription(SensorEntityDescription, frozen_or_thawed=Tru
 
     quatt_features: QuattFeatureFlags = QuattFeatureFlags()
     quatt_entity_class: type[QuattEntity] = QuattSensor
+    quatt_unique_id_key: str | None = None
 
 
 class QuattBinarySensorEntityDescription(
@@ -613,6 +813,7 @@ class QuattBinarySensorEntityDescription(
 
     quatt_features: QuattFeatureFlags = QuattFeatureFlags()
     quatt_entity_class: type[QuattEntity] = QuattBinarySensor
+    quatt_unique_id_key: str | None = None
 
 
 class QuattSelectEntityDescription(SelectEntityDescription, frozen_or_thawed=True):
@@ -620,6 +821,7 @@ class QuattSelectEntityDescription(SelectEntityDescription, frozen_or_thawed=Tru
 
     quatt_features: QuattFeatureFlags = QuattFeatureFlags()
     quatt_entity_class: type[QuattEntity] = QuattSelect
+    quatt_unique_id_key: str | None = None
 
 
 class QuattSwitchEntityDescription(SwitchEntityDescription, frozen_or_thawed=True):
@@ -627,6 +829,7 @@ class QuattSwitchEntityDescription(SwitchEntityDescription, frozen_or_thawed=Tru
 
     quatt_features: QuattFeatureFlags = QuattFeatureFlags()
     quatt_entity_class: type[QuattEntity] = QuattSwitch
+    quatt_unique_id_key: str | None = None
 
 
 class QuattNumberEntityDescription(NumberEntityDescription, frozen_or_thawed=True):
@@ -634,3 +837,297 @@ class QuattNumberEntityDescription(NumberEntityDescription, frozen_or_thawed=Tru
 
     quatt_features: QuattFeatureFlags = QuattFeatureFlags()
     quatt_entity_class: type[QuattEntity] = QuattNumber
+    quatt_unique_id_key: str | None = None
+
+
+class QuattClimateEntityDescription(ClimateEntityDescription, frozen_or_thawed=True):
+    """A class that describes Quatt climate entities."""
+
+    quatt_features: QuattFeatureFlags = QuattFeatureFlags()
+    quatt_entity_class: type[QuattEntity] = ClimateEntity
+    quatt_unique_id_key: str | None = None
+
+
+class QuattChillClimate(QuattEntity, ClimateEntity):
+    """Climate entity for Quatt chill devices."""
+
+    _attr_fan_modes = [fan_mode.display_value for fan_mode in QuattChillFanMode]
+    _attr_hvac_modes = [HVACMode.HEAT, HVACMode.COOL, HVACMode.OFF]
+    _attr_name = None
+    _attr_precision = PRECISION_TENTHS
+    _attr_target_temperature_step = 1.0
+    _attr_supported_features = (
+        ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE
+    )
+
+    def __init__(
+        self,
+        device_name: str,
+        device_id: str,
+        sensor_key: str,
+        coordinator: QuattDataUpdateCoordinator,
+        entity_description: QuattClimateEntityDescription,
+        device_kind: QuattDeviceKind,
+    ) -> None:
+        """Initialize the chill climate entity."""
+        super().__init__(
+            device_name,
+            device_id,
+            sensor_key,
+            coordinator,
+            device_kind,
+            entity_description.quatt_unique_id_key,
+        )
+        self.entity_description = entity_description
+
+    @property
+    def chill_index(self) -> int | None:
+        """Return the current Chill list index for this climate entity."""
+        return self._current_chill_index()
+
+    def _chill_value(self, key: str) -> Any:
+        """Return a value from the current Chill data."""
+        chill_index = self.chill_index
+        if chill_index is None:
+            return None
+        return self.coordinator.get_value(f"chills.{chill_index}.{key}")
+
+    def _async_set_chill_values(self, updates: Mapping[str, Any]) -> None:
+        """Optimistically update the cached chill values."""
+        chill_index = self.chill_index
+        if chill_index is None:
+            return
+
+        data = deepcopy(self.coordinator.data)
+        current_node = data
+        if isinstance(current_node, dict) and "result" in current_node:
+            current_node = current_node["result"]
+
+        if not isinstance(current_node, dict):
+            return
+
+        chills = current_node.get("chills")
+        if not isinstance(chills, list) or chill_index >= len(chills):
+            return
+
+        chill = chills[chill_index]
+        if not isinstance(chill, dict):
+            return
+
+        for value_path, value in updates.items():
+            node = chill
+            parts = value_path.split(".")
+            for part in parts[:-1]:
+                child = node.setdefault(part, {})
+                if not isinstance(child, dict):
+                    return
+                node = child
+            node[parts[-1]] = value
+
+        self.coordinator.async_set_updated_data(data)
+
+    @staticmethod
+    def _status_to_hvac_mode(status: Any, source: str) -> HVACMode | None:
+        """Convert a Quatt Chill status or mode value to an HVAC mode."""
+        if chill_status := QuattChillStatus.from_api_value(status):
+            return chill_status.hvac_mode
+        if chill_mode := QuattChillMode.from_api_value(status):
+            return chill_mode.hvac_mode
+        if isinstance(status, str):
+            _LOGGER.debug("Unknown Chill %s value: %s", source, status)
+        return None
+
+    @property
+    def hvac_mode(self) -> HVACMode:
+        """Return the current HVAC mode."""
+        status = self._chill_value("status")
+        if hvac_mode := self._status_to_hvac_mode(status, "status"):
+            return hvac_mode
+
+        is_on = self._chill_value("isOn.value")
+        if not is_on:
+            return HVACMode.OFF
+
+        mode = self._chill_value("mode")
+        if hvac_mode := self._status_to_hvac_mode(mode, "mode"):
+            return hvac_mode
+
+        return HVACMode.OFF
+
+    @property
+    def current_temperature(self) -> float | None:
+        """Return the current temperature."""
+        return self._chill_value("ambientTemperature")
+
+    @property
+    def target_temperature(self) -> float | None:
+        """Return the target temperature."""
+        hvac_mode = self.hvac_mode
+        if hvac_mode == HVACMode.OFF:
+            mode = self._chill_value("mode")
+            hvac_mode = self._status_to_hvac_mode(mode, "mode")
+
+        if hvac_mode == HVACMode.COOL:
+            return self._chill_value("coolingTargetTemperature")
+        if hvac_mode == HVACMode.HEAT:
+            return self._chill_value("heatingTargetTemperature")
+        return None
+
+    @property
+    def target_temperature_high(self) -> float | None:
+        """Return the maximum target temperature."""
+        return self._chill_value("maxTargetTemperature")
+
+    @property
+    def target_temperature_low(self) -> float | None:
+        """Return the minimum target temperature."""
+        return self._chill_value("minTargetTemperature")
+
+    @property
+    def min_temp(self) -> float:
+        """Return the minimum temperature."""
+        min_temp = self._chill_value("minTargetTemperature")
+        return float(min_temp) if min_temp is not None else 5.0
+
+    @property
+    def max_temp(self) -> float:
+        """Return the maximum temperature."""
+        max_temp = self._chill_value("maxTargetTemperature")
+        return float(max_temp) if max_temp is not None else 40.0
+
+    @property
+    def temperature_unit(self) -> str:
+        """Return the unit of measurement."""
+        return UnitOfTemperature.CELSIUS
+
+    @property
+    def fan_mode(self) -> str | None:
+        """Return the current fan mode."""
+        fan_mode = self._chill_value("fanMode")
+        if isinstance(fan_mode, str):
+            return _format_chill_enum_value("fanMode", fan_mode)
+        return None
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        """Set the HVAC mode."""
+        remote_client = self.coordinator.client
+        if not isinstance(remote_client, QuattCicRemoteApiClient):
+            raise NotImplementedError("HVAC mode setting requires remote API")
+
+        chill_uuid = self._chill_value("uuid")
+        if not chill_uuid:
+            raise RuntimeError("Cannot find chill UUID")
+
+        if hvac_mode == HVACMode.OFF:
+            data = {"type": "SET_ON_OFF", "on": False}
+            _LOGGER.debug("Turning off chill %s: %s", chill_uuid, data)
+            success = await remote_client.update_chill_action(chill_uuid, data)
+            if not success:
+                raise RuntimeError(f"Failed to set HVAC mode to {hvac_mode}")
+
+            self._async_set_chill_values(
+                {
+                    "isOn.value": False,
+                    "status": QuattChillStatus.OFF.value,
+                }
+            )
+            return
+
+        if hvac_mode == HVACMode.COOL:
+            chill_mode = QuattChillMode.COOLING
+            chill_status = QuattChillStatus.COOLING
+        elif hvac_mode == HVACMode.HEAT:
+            chill_mode = QuattChillMode.HEATING
+            chill_status = QuattChillStatus.HEATING
+        else:
+            raise ValueError(f"Unsupported HVAC mode: {hvac_mode}")
+
+        if self.hvac_mode == HVACMode.OFF:
+            data = {"type": "SET_ON_OFF", "on": True}
+            _LOGGER.debug("Turning on chill %s: %s", chill_uuid, data)
+            success = await remote_client.update_chill_action(chill_uuid, data)
+            if not success:
+                raise RuntimeError(f"Failed to set HVAC mode to {hvac_mode}")
+            self._async_set_chill_values({"isOn.value": True})
+
+        data = {"type": "SET_MODE", "mode": chill_mode.value}
+        _LOGGER.debug("Setting HVAC mode for chill %s: %s", chill_uuid, data)
+        success = await remote_client.update_chill_action(chill_uuid, data)
+        if not success:
+            raise RuntimeError(f"Failed to set HVAC mode to {hvac_mode}")
+
+        self._async_set_chill_values(
+            {
+                "isOn.value": True,
+                "mode": chill_mode.value,
+                "status": chill_status.value,
+            }
+        )
+
+    async def async_set_fan_mode(self, fan_mode: str) -> None:
+        """Set the fan mode."""
+        remote_client = self.coordinator.client
+        if not isinstance(remote_client, QuattCicRemoteApiClient):
+            raise NotImplementedError("Fan mode setting requires remote API")
+
+        chill_fan_mode = QuattChillFanMode.from_display_value(fan_mode)
+        if chill_fan_mode is None:
+            raise ValueError(f"Unsupported fan mode: {fan_mode}")
+
+        chill_uuid = self._chill_value("uuid")
+        if not chill_uuid:
+            raise RuntimeError("Cannot find chill UUID")
+
+        data = {"type": "SET_FAN_MODE", "fanMode": chill_fan_mode.value}
+        _LOGGER.debug("Setting fan mode for chill %s: %s", chill_uuid, data)
+        success = await remote_client.update_chill_action(chill_uuid, data)
+        if success:
+            self._async_set_chill_values({"fanMode": chill_fan_mode.value})
+        else:
+            raise RuntimeError(f"Failed to set fan mode to {fan_mode}")
+
+    async def async_set_temperature(self, **kwargs) -> None:
+        """Set the target temperature."""
+        remote_client = self.coordinator.client
+        if not isinstance(remote_client, QuattCicRemoteApiClient):
+            raise NotImplementedError("Temperature setting requires remote API")
+
+        temperature = kwargs.get("temperature")
+        if temperature is None:
+            return
+        temperature = int(round(temperature))
+
+        chill_uuid = self._chill_value("uuid")
+        if not chill_uuid:
+            raise RuntimeError("Cannot find chill UUID")
+
+        hvac_mode = self.hvac_mode
+        if hvac_mode == HVACMode.OFF:
+            mode = self._chill_value("mode")
+            hvac_mode = self._status_to_hvac_mode(mode, "mode")
+
+        if hvac_mode == HVACMode.COOL:
+            data = {
+                "type": "SET_COOLING_TARGET_TEMPERATURE",
+                "coolingTargetTemperature": temperature,
+            }
+        elif hvac_mode == HVACMode.HEAT:
+            data = {
+                "type": "SET_HEATING_TARGET_TEMPERATURE",
+                "heatingTargetTemperature": temperature,
+            }
+        else:
+            raise RuntimeError(f"Unknown chill mode: {hvac_mode}")
+
+        _LOGGER.debug("Setting target temperature for chill %s: %s", chill_uuid, data)
+        success = await remote_client.update_chill_action(chill_uuid, data)
+        if success:
+            self._async_set_chill_values(
+                {
+                    "coolingTargetTemperature"
+                    if hvac_mode == HVACMode.COOL
+                    else "heatingTargetTemperature": temperature
+                }
+            )
+        else:
+            raise RuntimeError(f"Failed to set temperature to {temperature}")

--- a/custom_components/quatt/entity_setup.py
+++ b/custom_components/quatt/entity_setup.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Mapping
+from dataclasses import replace
 import logging
+from typing import Any
 
 from homeassistant.core import HomeAssistant
 import homeassistant.helpers.device_registry as dr
@@ -14,6 +17,56 @@ from .coordinator import QuattCicDataUpdateCoordinator
 _LOGGER = logging.getLogger(__name__)
 
 
+def _chill_unique_id_key(key: str, index: int) -> str:
+    """Return a Chill entity key without the response-list index."""
+    indexed_chill_key = f"chills.{index}"
+    if key == indexed_chill_key:
+        return "chills"
+    if key.startswith(f"{indexed_chill_key}."):
+        return f"chills.{key.removeprefix(f'{indexed_chill_key}.')}"
+    return key
+
+
+def _entity_unique_id_key(entity_description: Any) -> str:
+    """Return the entity description key used for the Home Assistant unique ID."""
+    return entity_description.quatt_unique_id_key or entity_description.key
+
+
+def create_chill_entity_descriptions(
+    coordinator: QuattCicDataUpdateCoordinator,
+    base_entity_descriptions: dict[str, list],
+    create_entity_descriptions: Callable[[int], list],
+) -> tuple[dict[str, list], dict[str, str], dict[str, QuattDeviceKind]]:
+    """Add dynamic Chill entity descriptions to a platform's base descriptions."""
+    entity_descriptions = {**base_entity_descriptions}
+    device_names: dict[str, str] = {}
+    device_kinds: dict[str, QuattDeviceKind] = {}
+
+    chill_list = coordinator.get_value("chills", [])
+    if not isinstance(chill_list, list):
+        return entity_descriptions, device_names, device_kinds
+
+    for index, chill in enumerate(chill_list):
+        if not isinstance(chill, dict) or not (chill_uuid := chill.get("uuid")):
+            _LOGGER.error("Cannot set up Chill at index %s: missing UUID", index)
+            continue
+
+        device_id = chill_uuid
+        entity_descriptions[device_id] = [
+            replace(
+                entity_description,
+                quatt_unique_id_key=_chill_unique_id_key(
+                    entity_description.key, index
+                ),
+            )
+            for entity_description in create_entity_descriptions(index)
+        ]
+        device_names[device_id] = chill.get("name") or f"Chill {index + 1}"
+        device_kinds[device_id] = QuattDeviceKind.DEVICE
+
+    return entity_descriptions, device_names, device_kinds
+
+
 async def async_setup_entities(
     hass: HomeAssistant,
     coordinator: QuattCicDataUpdateCoordinator,
@@ -21,6 +74,8 @@ async def async_setup_entities(
     remote: bool,
     entity_descriptions: dict[str, list],
     entity_domain: str,
+    device_names: Mapping[str, str] | None = None,
+    device_kinds: Mapping[str, QuattDeviceKind] | None = None,
 ):
     """Set up CIC entities on the given platform.
 
@@ -41,14 +96,14 @@ async def async_setup_entities(
     _LOGGER.debug("All electric active: %s", all_electric_active)
     _LOGGER.debug("boiler OpenTherm: %s", is_boiler_opentherm)
 
-    # Create only those sensors that make sense for this installation type.
-    # Remove sensors that are not applicable based on the configuration.
+    # Create only those entities that make sense for this installation type.
+    # Remove entities that are not applicable based on the configuration.
     # This can occur when the configuration changes, e.g., from hybrid or duo to all-electric.
     device_reg = dr.async_get(hass)
     devices = dr.async_entries_for_config_entry(device_reg, entry.entry_id)
     device_ids = {dev.id for dev in devices}
 
-    # Determine which sensors to create based on the detected configuration
+    # Determine which entities to create based on the detected configuration
     flag_conditions = [
         ("hybrid", not all_electric_active),
         ("all_electric", all_electric_active),
@@ -56,15 +111,15 @@ async def async_setup_entities(
         ("opentherm", is_boiler_opentherm),
     ]
 
-    # Flatten out all sensor descriptions
+    # Flatten out all entity descriptions
     flat_descriptions = [
-        sensor_description
-        for device_sensors in entity_descriptions.values()
-        for sensor_description in device_sensors
+        entity_description
+        for device_entities in entity_descriptions.values()
+        for entity_description in device_entities
     ]
 
-    # Determine which sensors to create based on the flags
-    sensor_keys: dict[str, bool] = {}
+    # Determine which entities to create based on the flags
+    entity_keys: dict[str, bool] = {}
     for desc in flat_descriptions:
         features = desc.quatt_features
 
@@ -72,11 +127,21 @@ async def async_setup_entities(
         if not any(getattr(features, flag) for flag, _ in flag_conditions) or all(
             condition for flag, condition in flag_conditions if getattr(features, flag)
         ):
-            # Include the sensor and the mobile API status
-            sensor_keys[desc.key] = features.mobile_api
+            # Include the entity and the mobile API status
+            entity_keys[desc.key] = features.mobile_api
 
-    # Remove not applicable sensors
     hub_id = (entry.unique_id or entry.entry_id).strip()
+    expected_unique_ids = {
+        f"{hub_id}:{device_id}:{_entity_unique_id_key(entity_description)}"
+        for device_id, device_entity_descriptions in entity_descriptions.items()
+        for entity_description in device_entity_descriptions
+        if entity_description.key in entity_keys
+    }
+    expected_unique_id_prefixes = {
+        f"{hub_id}:{device_id}:" for device_id in entity_descriptions
+    }
+
+    # Remove not applicable entities
     for dev_id in device_ids:
         for entry_reg in er.async_entries_for_device(
             registry, dev_id, include_disabled_entities=True
@@ -85,7 +150,20 @@ async def async_setup_entities(
                 entry_reg.config_entry_id == entry.entry_id
                 and entry_reg.domain == entity_domain
                 and entry_reg.platform == DOMAIN
-                and not any(entry_reg.unique_id.endswith(key) for key in sensor_keys)
+                and entry_reg.unique_id not in expected_unique_ids
+                and (
+                    any(
+                        entry_reg.unique_id.startswith(prefix)
+                        for prefix in expected_unique_id_prefixes
+                    )
+                    or (
+                        remote
+                        and (
+                            ":chills." in entry_reg.unique_id
+                            or entry_reg.unique_id.endswith(":chills")
+                        )
+                    )
+                )
             ):
                 _LOGGER.info(
                     "[%s] Removing obsolete entity: %s (%s)",
@@ -109,30 +187,36 @@ async def async_setup_entities(
             )
             device_reg.async_remove_device(dev_id)
 
-    # Create sensor entities based on the filtered sensor keys
+    # Create entities based on the filtered entity keys
     device_name_map = {d["id"]: d["name"] for d in DEVICE_LIST}
+    if device_names is not None:
+        device_name_map.update(device_names)
+
     device_kind_map = {d["id"]: d["kind"] for d in DEVICE_LIST}
-    sensors: list = []
-    for device_id, sensor_descriptions in entity_descriptions.items():
+    if device_kinds is not None:
+        device_kind_map.update(device_kinds)
+
+    entities: list = []
+    for device_id, device_entity_descriptions in entity_descriptions.items():
         device_kind = device_kind_map.get(device_id, QuattDeviceKind.DEVICE)
-        for sensor_description in sensor_descriptions:
-            # Skip sensors that are not selected based on the installation type
-            if sensor_description.key not in sensor_keys:
+        for entity_description in device_entity_descriptions:
+            # Skip entities that are not selected based on the installation type
+            if entity_description.key not in entity_keys:
                 continue
 
-            # Skip sensors that do not match the remote indicator
-            if sensor_keys[sensor_description.key] != remote:
+            # Skip entities that do not match the remote indicator
+            if entity_keys[entity_description.key] != remote:
                 continue
 
-            sensors.append(
-                sensor_description.quatt_entity_class(
+            entities.append(
+                entity_description.quatt_entity_class(
                     device_name=device_name_map.get(device_id, device_id),
                     device_id=device_id,
-                    sensor_key=sensor_description.key,
+                    sensor_key=entity_description.key,
                     coordinator=coordinator,
-                    entity_description=sensor_description,
+                    entity_description=entity_description,
                     device_kind=device_kind,
                 )
             )
 
-    return sensors
+    return entities

--- a/custom_components/quatt/number.py
+++ b/custom_components/quatt/number.py
@@ -77,7 +77,9 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
     coordinators = hass.data[DOMAIN][entry.entry_id]
 
     local_coordinator: QuattDataUpdateCoordinator | None = coordinators.get("cic_local")
-    remote_coordinator: QuattDataUpdateCoordinator | None = coordinators.get("cic_remote")
+    remote_coordinator: QuattDataUpdateCoordinator | None = coordinators.get(
+        "cic_remote"
+    )
     home_battery_coordinator: QuattDataUpdateCoordinator | None = coordinators.get(
         "home_battery"
     )

--- a/custom_components/quatt/select.py
+++ b/custom_components/quatt/select.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-import logging
-
 from homeassistant.components.select import DOMAIN as SELECT_DOMAIN
 from homeassistant.core import HomeAssistant
 
@@ -63,15 +61,15 @@ SELECTS = {
     DEVICE_THERMOSTAT_ID: [],
 }
 
-_LOGGER = logging.getLogger(__name__)
-
 
 async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
     """Set up the select platform."""
     coordinators = hass.data[DOMAIN][entry.entry_id]
 
     local_coordinator: QuattDataUpdateCoordinator | None = coordinators.get("cic_local")
-    remote_coordinator: QuattDataUpdateCoordinator | None = coordinators.get("cic_remote")
+    remote_coordinator: QuattDataUpdateCoordinator | None = coordinators.get(
+        "cic_remote"
+    )
 
     selects: list[QuattSelect] = []
     if local_coordinator is not None:

--- a/custom_components/quatt/sensor.py
+++ b/custom_components/quatt/sensor.py
@@ -44,11 +44,12 @@ from .const import (
 from .coordinator import QuattDataUpdateCoordinator
 from .entity import (
     QuattFeatureFlags,
+    QuattChillSensor,
     QuattSensor,
     QuattSensorEntityDescription,
     QuattSystemSensor,
 )
-from .entity_setup import async_setup_entities
+from .entity_setup import async_setup_entities, create_chill_entity_descriptions
 
 
 def create_heatpump_sensor_entity_descriptions(
@@ -265,6 +266,127 @@ def create_heatpump_sensor_entity_descriptions(
                 duo=is_duo,
                 mobile_api=True,
             ),
+        ),
+    ]
+
+
+def create_chill_sensor_entity_descriptions(
+    index: int,
+) -> list[QuattSensorEntityDescription]:
+    """Create the chill sensor entity descriptions based on the index."""
+    return [
+        QuattSensorEntityDescription(
+            name="Name",
+            key=f"chills.{index}.name",
+            icon="mdi:label",
+            entity_category=EntityCategory.DIAGNOSTIC,
+            quatt_features=QuattFeatureFlags(
+                mobile_api=True,
+            ),
+            quatt_entity_class=QuattChillSensor,
+        ),
+        QuattSensorEntityDescription(
+            name="Color",
+            key=f"chills.{index}.color",
+            icon="mdi:palette",
+            entity_category=EntityCategory.DIAGNOSTIC,
+            quatt_features=QuattFeatureFlags(
+                mobile_api=True,
+            ),
+            quatt_entity_class=QuattChillSensor,
+        ),
+        QuattSensorEntityDescription(
+            name="Mode",
+            key=f"chills.{index}.mode",
+            icon="mdi:autorenew",
+            quatt_features=QuattFeatureFlags(
+                mobile_api=True,
+            ),
+            quatt_entity_class=QuattChillSensor,
+        ),
+        QuattSensorEntityDescription(
+            name="Fan mode",
+            key=f"chills.{index}.fanMode",
+            icon="mdi:fan",
+            quatt_features=QuattFeatureFlags(
+                mobile_api=True,
+            ),
+            quatt_entity_class=QuattChillSensor,
+        ),
+        QuattSensorEntityDescription(
+            name="Ambient temperature",
+            key=f"chills.{index}.ambientTemperature",
+            icon="mdi:thermometer",
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+            device_class=SensorDeviceClass.TEMPERATURE,
+            suggested_display_precision=1,
+            state_class=SensorStateClass.MEASUREMENT,
+            quatt_features=QuattFeatureFlags(
+                mobile_api=True,
+            ),
+            quatt_entity_class=QuattChillSensor,
+        ),
+        QuattSensorEntityDescription(
+            name="Minimum target temperature",
+            key=f"chills.{index}.minTargetTemperature",
+            icon="mdi:thermometer-chevron-down",
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+            device_class=SensorDeviceClass.TEMPERATURE,
+            suggested_display_precision=0,
+            state_class=SensorStateClass.MEASUREMENT,
+            entity_category=EntityCategory.DIAGNOSTIC,
+            entity_registry_enabled_default=False,
+            quatt_features=QuattFeatureFlags(
+                mobile_api=True,
+            ),
+            quatt_entity_class=QuattChillSensor,
+        ),
+        QuattSensorEntityDescription(
+            name="Maximum target temperature",
+            key=f"chills.{index}.maxTargetTemperature",
+            icon="mdi:thermometer-chevron-up",
+            native_unit_of_measurement=UnitOfTemperature.CELSIUS,
+            device_class=SensorDeviceClass.TEMPERATURE,
+            suggested_display_precision=0,
+            state_class=SensorStateClass.MEASUREMENT,
+            entity_category=EntityCategory.DIAGNOSTIC,
+            entity_registry_enabled_default=False,
+            quatt_features=QuattFeatureFlags(
+                mobile_api=True,
+            ),
+            quatt_entity_class=QuattChillSensor,
+        ),
+        QuattSensorEntityDescription(
+            name="Status",
+            key=f"chills.{index}.status",
+            icon="mdi:information",
+            quatt_features=QuattFeatureFlags(
+                mobile_api=True,
+            ),
+            quatt_entity_class=QuattChillSensor,
+        ),
+        QuattSensorEntityDescription(
+            name="Update state",
+            key=f"chills.{index}.updateState",
+            icon="mdi:cloud-check",
+            entity_category=EntityCategory.DIAGNOSTIC,
+            entity_registry_enabled_default=False,
+            quatt_features=QuattFeatureFlags(
+                mobile_api=True,
+            ),
+            quatt_entity_class=QuattChillSensor,
+        ),
+        QuattSensorEntityDescription(
+            name="Last updated",
+            key=f"chills.{index}.lastUpdatedAt",
+            icon="mdi:clock-outline",
+            device_class=SensorDeviceClass.TIMESTAMP,
+            entity_category=EntityCategory.DIAGNOSTIC,
+            entity_registry_enabled_default=False,
+            quatt_features=QuattFeatureFlags(
+                mobile_api=True,
+            ),
+            quatt_entity_class=QuattChillSensor,
         ),
     ]
 
@@ -1470,13 +1592,23 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
         )
 
     if remote_coordinator:
+        entity_descriptions, device_names, device_kinds = (
+            create_chill_entity_descriptions(
+                remote_coordinator,
+                SENSORS,
+                create_chill_sensor_entity_descriptions,
+            )
+        )
+
         sensors += await async_setup_entities(
             hass=hass,
             coordinator=remote_coordinator,
             entry=entry,
             remote=True,
-            entity_descriptions=SENSORS,
+            entity_descriptions=entity_descriptions,
             entity_domain=SENSOR_DOMAIN,
+            device_names=device_names,
+            device_kinds=device_kinds,
         )
 
     if home_battery_coordinator is not None:

--- a/custom_components/quatt/switch.py
+++ b/custom_components/quatt/switch.py
@@ -66,7 +66,9 @@ async def async_setup_entry(hass: HomeAssistant, entry, async_add_devices):
     coordinators = hass.data[DOMAIN][entry.entry_id]
 
     local_coordinator: QuattDataUpdateCoordinator | None = coordinators.get("cic_local")
-    remote_coordinator: QuattDataUpdateCoordinator | None = coordinators.get("cic_remote")
+    remote_coordinator: QuattDataUpdateCoordinator | None = coordinators.get(
+        "cic_remote"
+    )
 
     switches: list[QuattSwitch] = []
     if local_coordinator is not None:


### PR DESCRIPTION
## Summary
Add Quatt Chill support with a new climate platform and dynamic Chill entities 

## Details
- Integrate Chill climate control for hvac mode, target temperature, and fan mode 
- Expose Chill status and diagnostic sensors/binary sensors 
- Format Chill enum-style API values for Home Assistant display 
- Fetch Chill data from the remote API and support Chill actions through the mobile API client 
